### PR TITLE
Bolded the note that users cannot see or install tekton using the svc acct.

### DIFF
--- a/workshop/content/install-tekton-operator.adoc
+++ b/workshop/content/install-tekton-operator.adoc
@@ -7,8 +7,8 @@ and manage pipelines for every single user in the cluster.
 
 To install the operator globally, you need to be a cluster administrator user. In this workshop environment,
 the operator has already been installed for you. Nevertheless, this is the process we followed
-in order to install the operator. These instructions are for reference, as you will not be able
-to see these screens in the embedded console in the workshop due to your user's lack of the required privileges.
+in order to install the operator. **These instructions are for reference, as you will not be able
+to see these screens in the embedded console in the workshop due to your user's lack of the required privileges.**
 
 == Install process
 


### PR DESCRIPTION
When I ran through the lab, I missed the text saying that I couldn't see the screens below in the Install Tekton Operator section.  It makes sense because we are using the svc acct and not cluster admin, but I bet students will ask questions like "I tried to follow this screenshot and didn't see it!"  So I bolded the text to make it a little more clear.