### PR TITLE
Remove Operator Installation Instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 Lab - OpenShift Pipelines with Tekton
 ====================
 
-This workshop provides an introduction to OpenShift Pipelines with Tekton. Please check [releases](https://github.com/openshift-labs/lab-tekton-pipelines/releases) for the latest version of the workshop.
+This workshop provides an introduction to OpenShift Pipelines with Tekton.
+Please check [releases](https://github.com/openshift-labs/lab-tekton-pipelines/releases)
+for the latest version of the workshop and also make sure to note if a version
+released has been deprecated. 
 
-The workshop uses the HomeRoom workshop environment in the learning portal configuration. You will need to be a cluster admin in order to deploy it.
+The workshop uses the HomeRoom workshop environment in the learning portal configuration.
+You will need to be a cluster admin in order to deploy it.
 
 When the URL for the workshop environment is accessed, a workshop session will be created on demand.
-
-Installing OpenShift Pipelines Operator
----------------------------------------
-
-In order to run this workshop, the OpenShift Pipelines operator will need to be globally installed on the cluster that is hosting the workshop.
-
-Installation instructions can be found [here](https://github.com/openshift/pipelines-tutorial/blob/master/install-operator.md) for installing the latest version of the operator.
 
 Deploying the Workshop
 ----------------------


### PR DESCRIPTION
Manually installing the OpenShift Pipelines Operator was resolved by [92de461](https://github.com/openshift-labs/lab-tekton-pipelines/commit/92de461d0b3f22fd294f4ce5a26a9641768a0d8e).

Version 1.0 would still rely on manual installation of the operator, but the version is soon to be deprecated since the 4.2 web console will no longer align with the content in the workshop.