### PR TITLE
Use Service Instead of IP for MongoDB and List PipelineResource Types

### DIFF
--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -2,7 +2,7 @@ A pipeline defines a number of tasks that should be executed and how they intera
 with each other via their inputs and outputs.
 
 In this tutorial, you will create a pipeline that takes the source code of a Node.js
-application from GitHub and then builds and deploys it on OpenShift using S2I and Buildah.
+application from GitHub and then builds and deploys it on OpenShift using s2i and Buildah.
 
 Below is a YAML file that represents the above pipeline:
 
@@ -47,7 +47,7 @@ This pipeline performs the following:
 1. Clones the source code of the application from a git repository (i.e., `app-git` resource)
 2. Builds the container image using the `s2i-nodejs` task that generates a Dockerfile for the application and uses Buildah to build the image
 3. The application image is pushed to an image registry (i.e., `app-image` resource)
-4. The new application image is deployed on OpenShift using the `openshift-cli` task
+4. The new application image is deployed on OpenShift using the `openshift-client` task
 
 The pipeline definition above shows how tasks can be added to a pipeline.
 Each pipeline has a `tasks` property. Under this property, each `task` has a `name`.

--- a/workshop/content/exercises/deploy-sample-app.adoc
+++ b/workshop/content/exercises/deploy-sample-app.adoc
@@ -1,6 +1,6 @@
 For this tutorial, you're going to use a simple Node.js application that interacts with a
 MongoDB database. The workshop is configured to provide you a pre-created OpenShift project
-(i.e., Kubernetes namespace) where you will set up supplementary resources for your
+(i.e. Kubernetes namespace) where you will set up supplementary resources for your
 application for its eventual deployment.
 
 We can verify the name of the project with:
@@ -44,25 +44,29 @@ installed. It also sets environment variables using the `-e` option. These envir
 variables are needed by MongoDB for its deployment, such as the username, database name,
 password, and the admin password.
 
-Next, let's grab the IP address of the database container. This will be used to connect
-the `nodejs-ex` application to the MongoDB. Run the command below:
-
-[source,bash,role=execute-1]
-----
-export CIP=$(oc get svc -o jsonpath={.items[0].spec.clusterIP})
-----
-
-The above command returns the services running in your OpenShift project and grabs
-the `clusterIP` from the first element returned, which will correspond to the MongoDB
-database you just deployed.
-
 The last step is to set an environment variable for `nodejs-ex` that will provide the
-application the URL to connect to the MongoDB. This will use the IP address stored
-as the environment variable `CIP` above. To do this, run the following command:
+application the url to connect to the MongoDB. This will use the service name of the
+MongoDB (i.e. `mongodb-36-centos7`) stored as part of an environment variable.
+
+A service is an abstract way to expose an application running on a set of pods as a network
+service. Using this service name will allow `nodejs-ex` to reference a consistent endpoint in
+the event the pod hosting your MongoDB container is updated from events such as scaling
+pods up or down or re-deploying your MongoDB container image with updates.
+
+You can see all the services, including the one for `nodejs-ex` in your OpenShift project
+by running the following command:
 
 [source,bash,role=execute-1]
 ----
-oc set env dc/nodejs-ex MONGO_URL="mongodb://admin:secret@$CIP:27017/mongo_db"
+oc get services
+----
+
+Now that you are familiar with Kubernetes services, go ahead a connect `nodejs-ex` to
+the MongoDB. To do this, run the following command:
+
+[source,bash,role=execute-1]
+----
+oc set env dc/nodejs-ex MONGO_URL="mongodb://admin:secret@mongodb-36-centos7:27017/mongo_db"
 ----
 
 To verify the resources needed to support `nodejs-ex` and the MongoDB have been created,
@@ -95,9 +99,11 @@ is shown in the image below:
 image:../images/topology-view.png[Topology View]
 
 You'll notice the white circle around the `nodejs-ex` deployment config. This means
-that `nodejs-ex` isn't running yet.
+that `nodejs-ex` isn't running yet. More specifically, no container hosting the `nodejs-ex`
+application has been created, built, and deployed yet. This will happen via the CI/CD pipeline
+you eventually will create.
 
-The mongodb-36-centos7 deployment config has a dark blue circle around it, meaning that
+The `mongodb-36-centos7` deployment config has a dark blue circle around it, meaning that
 a pod is running with the MongoDB container on it. The MongoDB should be all set
 to support the `nodejs-ex` application at this point.
 

--- a/workshop/content/exercises/install-tasks.adoc
+++ b/workshop/content/exercises/install-tasks.adoc
@@ -2,6 +2,11 @@ Tasks consist of a number of steps that are executed sequentially. Each step is
 executed in a separate container within the same task pod. Tasks can have inputs
 and outputs in order to interact with other tasks as part of a pipeline.
 
+By hosting each step of a task in its own container, you can package all the tools
+that are needed for a particular step in the container image used by the step. Using OpenShift,
+these containers can be very easily created and deleted, so they only run when they are needed
+(i.e. during a CI/CD pipeline run).
+
 Here is an example of a Maven task for building a Maven-based Java application:
 
 [source,yaml]

--- a/workshop/content/exercises/pipeline-resources.adoc
+++ b/workshop/content/exercises/pipeline-resources.adoc
@@ -26,7 +26,22 @@ spec:
 
 You can see above that the resource has a name (i.e. `nodejs-ex-git`) and under
 the `spec` property we define that this pipeline resource has a type of `git`, meaning
-it is a git repository. The last property is `params`, which can be used to specify
+it is a git repository.
+
+The `type` of a pipeline resource corresponds to a list a valid options for pipeline resources.
+These valid options include:
+
+* `git` - indicates a pipeline resource is a GitHub repository
+* `image` - indicates a pipeline resource is a container image
+* `storage` - indicates a pipeline resource is a storage blob resource
+* `cluster` - indicates a pipeline resource is a Kubernetes cluster image
+* `pullRequest` - indicates a pipeline resource is an SCM pull request
+* `cloudEvent` - indicates a pipeline resource is a cloud event URI
+
+There will be more valid types added to the Tekton API moving forward, but you will
+only need to focus on the `git` and `image` types for this workshop.
+
+The last property of `nodejs-ex-git` is `params`, which can be used to specify
 the url associated with the git input.
 
 The following defines the OpenShift internal registry for the resulting `nodejs-ex`

--- a/workshop/content/exercises/serviceaccount.adoc
+++ b/workshop/content/exercises/serviceaccount.adoc
@@ -1,7 +1,7 @@
-In this workshop, the pipeline you create will use tools such as S2I and Buildah
+In this workshop, the pipeline you create will use tools such as s2i and Buildah
 to create a container image for an application and build the image.
 
-Building container images using build tools such as S2I, Buildah, Kaniko, etc.
+Building container images using build tools such as s2i, Buildah, Kaniko, etc.
 require privileged access to the cluster. OpenShift default security settings
 do not allow access to privileged containers unless specifically configured.
 
@@ -22,7 +22,7 @@ to OpenShift's internal image registry.
 
 `pipeline` will only be able to push to a section of OpenShift's internal image registry
 that corresponds to your OpenShift project namespace. This helps to separate projects
-on an OpenShift cluster. 
+on an OpenShift cluster.
 
 The `pipeline` service account will execute pipeline runs on your behalf. You will
 see an explicit reference for a service account when you trigger a pipeline run


### PR DESCRIPTION
This pull request changes how the `MONGO_URL` environment variable is set by using the MongoDB service name instead of an IP. 

It also explains the various types of pipeline resources.

It also adds information to the `Create Tasks` section about the benefits of running steps in separate containers. 