### PR TITLE
Change Image Used by openshift-client Task

### DIFF
--- a/code/tektontasks/openshift-client-task.yaml
+++ b/code/tektontasks/openshift-client-task.yaml
@@ -2,8 +2,6 @@ apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: openshift-client
-  labels:
-    app: tekton-workshop
 spec:
   inputs:
     params:
@@ -12,7 +10,7 @@ spec:
         default: help
   steps:
     - name: oc
-      image: quay.io/openshift-pipeline/openshift-cli:latest
+      image: quay.io/openshiftlabs/openshift-cli-tekton-workshop:2.0
       command: ["/usr/local/bin/oc"]
       args:
         - "${inputs.params.ARGS}"

--- a/workshop/content/exercises/task-definitions.adoc
+++ b/workshop/content/exercises/task-definitions.adoc
@@ -162,7 +162,7 @@ spec:
         default: help
   steps:
     - name: oc
-      image: quay.io/openshift-pipeline/openshift-cli:latest
+      image: quay.io/openshiftlabs/openshift-cli-tekton-workshop:2.0
       command: ["/usr/local/bin/oc"]
       args:
         - "${inputs.params.ARGS}"


### PR DESCRIPTION
This pull request changes the image used by the `openshift-client` task to use an image in our own Quay registry: `quay.io/openshiftlabs/openshift-cli-tekton-workshop:2.0`. This will help prevent the workshop from breaking by changes to the `quay.io/openshift-pipeline/openshift-cli:latest` image that was previously used. 