### PR TITLE
Change mongo_db to mongodb and Correct Typo

### DIFF
--- a/.workshop/settings.sh
+++ b/.workshop/settings.sh
@@ -1,5 +1,5 @@
 WORKSHOP_NAME=lab-tekton-pipelines
-WORKSHOP_IMAGE=quay.io/openshiftlabs/lab-tekton-pipelines:2.1
+WORKSHOP_IMAGE=quay.io/openshiftlabs/lab-tekton-pipelines:latest
 CONSOLE_IMAGE=quay.io/openshift/origin-console:4.2
 RESOURCE_BUDGET=custom
 MAX_SESSION_AGE=7200

--- a/workshop/content/exercises/deploy-sample-app.adoc
+++ b/workshop/content/exercises/deploy-sample-app.adoc
@@ -33,7 +33,7 @@ to your OpenShift project by running the following command:
 
 [source,bash,role=execute-1]
 ----
-oc new-app centos/mongodb-36-centos7 -e MONGODB_USER=admin MONGODB_DATABASE=mongo_db MONGODB_PASSWORD=secret MONGODB_ADMIN_PASSWORD=super-secret
+oc new-app centos/mongodb-36-centos7 -e MONGODB_USER=admin MONGODB_DATABASE=mongodb MONGODB_PASSWORD=secret MONGODB_ADMIN_PASSWORD=super-secret
 ----
 
 You should see `-> Success` in the output of the command, which verifies the successful
@@ -66,7 +66,7 @@ the MongoDB. To do this, run the following command:
 
 [source,bash,role=execute-1]
 ----
-oc set env dc/nodejs-ex MONGO_URL="mongodb://admin:secret@mongodb-36-centos7:27017/mongo_db"
+oc set env dc/nodejs-ex MONGO_URL="mongodb://admin:secret@mongodb-36-centos7:27017/mongodb"
 ----
 
 To verify the resources needed to support `nodejs-ex` and the MongoDB have been created,

--- a/workshop/content/exercises/web-console.adoc
+++ b/workshop/content/exercises/web-console.adoc
@@ -24,7 +24,7 @@ and ones that have failed (i.e. **Failed**).
 To view the current pipeline run, click on the pipeline run name under the **Name** column.
 
 After clicking on the pipeline run name, you should see the tasks as part of
-your pipeline executing similar to whats displayed below:
+your pipeline executing similar to what's displayed below:
 
 image:../images/web-console-tasks.png[Web Console Tasks]
 


### PR DESCRIPTION
This pull request changes the `MONGODB_DATABASE` from `mongo_db` to `mongodb`. A user of this workshop chose to manually write out commands and this led to an error later in the workshop. Removing the `_` will help avoid this issue in the future.

A small typo was corrected in the web console section.

Also changing image tag to `latest`. 