### PR TITLE
Fixed Tekton version

### DIFF
--- a/.workshop/build
+++ b/.workshop/build
@@ -20,7 +20,7 @@ mv -f code/* . && rmdir code
 mkdir -p .bin && echo "export PATH=$HOME/.bin:$PATH" >> .bash_profile
 
 # Releases for Tekton CLI at: https://github.com/tektoncd/cli/releases
-TKN_CLI_VERSION=0.5.0
+TKN_CLI_VERSION=0.7.0
 curl -kL https://github.com/tektoncd/cli/releases/download/v${TKN_CLI_VERSION}/tkn_${TKN_CLI_VERSION}_Linux_x86_64.tar.gz -o /tmp/tkn.tar.gz && \
 tar -xvzf /tmp/tkn.tar.gz -C /tmp && \
 chmod 755 /tmp/tkn && \

--- a/workshop/content/08trigger-pipeline.adoc
+++ b/workshop/content/08trigger-pipeline.adoc
@@ -45,9 +45,14 @@ tkn pipeline start deploy-pipeline \
 
 After running this command, the pipeline you created earlier is now running. Some pods get created to execute the tasks defined as part of the pipeline. After 4-5 minutes, the pipeline run should finish successfully.
 
-Additionally, you will begin to see the pipeline run logs immediately after the pod for the first task is done initializing.
-
 == Tekton CLI Logs
+
+To see the logs for your Tekton pipeline run, you can use the provided command or run the following:
+
+[source,bash,role=execute]
+----
+tkn pipelinerun logs $(tkn pipelineruns list | grep deploy-pipeline-run | awk '{print $1, $8}') -f
+----
 
 The logs output tells you what tasks are running as well as what step it is running. You’ll see the output structured as [task_name : step_name]. An example from this pipeline run is below for the _generate_ step of the build task:
 


### PR DESCRIPTION
The previous lab had errors due to the Tekton version that was used. Fixed it using vers 0.7.0. This new version of tkn would not automatically start the logs so an additional step was added to fix this.